### PR TITLE
Feature: Adding Stadium Map Vector for Interactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Currently, the map supports these features:
 - Roof can also be disabled
 
 However, the styling are a bit off for now, but most of the styling stuff are handled, including responsiveness.
+This map should be scale with the seats info provided.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+---
+
+## Stadium Map Usage
+
+Currently, the map supports these features:
+- Highlighting active sector
+- Enable/disable sectors for disabling interactions
+- Map is accessible-friendly (can be navigated using keyboards and touches)
+- Roof can also be disabled
+
+However, the styling are a bit off for now, but most of the styling stuff are handled, including responsiveness.

--- a/src/components/SectorNav.tsx
+++ b/src/components/SectorNav.tsx
@@ -11,7 +11,12 @@ export default function SectorNav() {
 
   return (
     <div className="flex items-center w-full justify-center">
-      <StadiumSectors onSelect={handleSelect} disableRoofSelection enabledSectors={enabledSectors} activeSector={router.query.id as string} />
+      <StadiumSectors
+        onSelect={handleSelect}
+        disableRoofSelection
+        enabledSectors={enabledSectors}
+        activeSector={router.query.id as string}
+      />
     </div>
   );
 }

--- a/src/components/SectorNav.tsx
+++ b/src/components/SectorNav.tsx
@@ -1,0 +1,17 @@
+import { seats } from "@/constant";
+import StadiumSectors from "./StadiumSectors";
+import { useRouter } from "next/router";
+
+export default function SectorNav() {
+  const router = useRouter();
+  const enabledSectors = seats.map((seat) => seat.section);
+  const handleSelect = (sector: { id: string }) => {
+    router.push(`/${sector.id}`);
+  };
+
+  return (
+    <div className="flex items-center w-full justify-center">
+      <StadiumSectors onSelect={handleSelect} disableRoofSelection enabledSectors={enabledSectors} activeSector={router.query.id as string} />
+    </div>
+  );
+}

--- a/src/components/StadiumSectors.tsx
+++ b/src/components/StadiumSectors.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Sector, sectors } from "../config/sectors";
+
+type StadiumSectorsProps = {
+  onSelect?: (sector: Pick<Sector, "id" | "capacity">) => void;
+  onHover?: (sector: Pick<Sector, "id" | "capacity">) => void;
+  disableRoofSelection?: boolean;
+  /**
+   * @description Array of sector IDs to be enabled
+   */
+  enabledSectors?: string[];
+  activeSector?: string;
+};
+
+export default function StadiumSectors(props: StadiumSectorsProps) {
+  const [mouseOver, setMouseOver] = useState<string | null>(null);
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, sector: Omit<Sector, "className">) => {
+    e.preventDefault();
+    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
+    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
+    props.onSelect?.({
+      id: sector.id,
+      capacity: sector.capacity,
+    });
+  }
+
+  const handleHover = (sector: Omit<Sector, "className">) => {
+    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
+    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
+    props.onHover?.({
+      id: sector.id,
+      capacity: sector.capacity,
+    });
+  };
+
+  const handleMouseOver = (sector: Omit<Sector, "className">) => {
+    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
+    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
+    setMouseOver(sector.id);
+  }
+
+  return (
+    <svg width="2139" height="1850" viewBox="0 0 2139 1750" className="w-[800px] h-auto">
+      <text fill="white" fontSize={64} x={380} y={120}>A</text>
+      <text fill="white" fontSize={64} x={0} y={880}>B</text>
+      <text fill="white" fontSize={64} x={1062} y={1800}>C</text>
+      <text fill="white" fontSize={64} x={2090} y={880}>D</text>
+      <text fill="white" fontSize={64} x={1700} y={120}>E</text>
+      <text fill="white" fontSize={56} x={1700} y={0}>🚅 LRT Station ▶</text>
+      <text fill="white" fontSize={96} x={1000} y={900}>{mouseOver}</text>
+      {
+        sectors.map(({className, ...sectorProps}) => (
+          <a
+            key={sectorProps.id}
+            id={sectorProps.id}
+            href=""
+            onClick={(e) => handleClick(e, sectorProps)}
+            onMouseOver={() => handleHover(sectorProps)}
+            onMouseEnter={() => handleMouseOver(sectorProps)}
+            onMouseLeave={() => setMouseOver(null)}
+          >
+            <path
+              data-disabled={props.enabledSectors && !props.enabledSectors.includes(sectorProps.id)}
+              data-active={props.activeSector === sectorProps.id}
+              className="hover:fill-[#444] data-[disabled=true]:fill-[#333] data-[active=true]:fill-[coral]"
+              {...sectorProps}
+            />
+          </a>
+        ))
+      }
+    </svg>
+  );
+}

--- a/src/components/StadiumSectors.tsx
+++ b/src/components/StadiumSectors.tsx
@@ -14,60 +14,87 @@ type StadiumSectorsProps = {
 
 export default function StadiumSectors(props: StadiumSectorsProps) {
   const [mouseOver, setMouseOver] = useState<string | null>(null);
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, sector: Omit<Sector, "className">) => {
-    e.preventDefault();
-    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
-    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
-    props.onSelect?.({
-      id: sector.id,
-      capacity: sector.capacity,
-    });
-  }
-
-  const handleHover = (sector: Omit<Sector, "className">) => {
-    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
-    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
-    props.onHover?.({
-      id: sector.id,
-      capacity: sector.capacity,
-    });
-  };
-
-  const handleMouseOver = (sector: Omit<Sector, "className">) => {
-    if (props.disableRoofSelection && sector.id.startsWith("roof")) return;
-    if (props.enabledSectors && !props.enabledSectors.includes(sector.id)) return;
-    setMouseOver(sector.id);
-  }
 
   return (
-    <svg width="2139" height="1850" viewBox="0 0 2139 1750" className="w-[800px] h-auto">
-      <text fill="white" fontSize={64} x={380} y={120}>A</text>
-      <text fill="white" fontSize={64} x={0} y={880}>B</text>
-      <text fill="white" fontSize={64} x={1062} y={1800}>C</text>
-      <text fill="white" fontSize={64} x={2090} y={880}>D</text>
-      <text fill="white" fontSize={64} x={1700} y={120}>E</text>
-      <text fill="white" fontSize={56} x={1700} y={0}>🚅 LRT Station ▶</text>
-      <text fill="white" fontSize={96} x={1000} y={900}>{mouseOver}</text>
-      {
-        sectors.map(({className, ...sectorProps}) => (
+    <svg
+      width="2139"
+      height="1850"
+      viewBox="0 0 2139 1750"
+      className="w-[800px] h-auto"
+    >
+      <text fill="white" fontSize={64} x={380} y={120}>
+        E
+      </text>
+      <text fill="white" fontSize={64} x={0} y={880}>
+        D
+      </text>
+      <text fill="white" fontSize={64} x={1062} y={1800}>
+        C
+      </text>
+      <text fill="white" fontSize={64} x={2090} y={880}>
+        B
+      </text>
+      <text fill="white" fontSize={64} x={1700} y={120}>
+        A
+      </text>
+      <text fill="white" fontSize={56} x={1700} y={0}>
+        🚅 LRT Station ▶
+      </text>
+      <text fill="white" fontSize={96} x={1000} y={900}>
+        {mouseOver}
+      </text>
+      {sectors.map(({ className, ...sectorProps }) => {
+        const isEnabled = props.enabledSectors?.includes(sectorProps.id);
+        const isRoof = sectorProps.id.startsWith("roof");
+
+        const handleClick = (
+          e: React.MouseEvent<HTMLAnchorElement>,
+          sector: Omit<Sector, "className">
+        ) => {
+          e.preventDefault();
+          if (props.disableRoofSelection && isRoof) return;
+          if (!isEnabled) return;
+          props.onSelect?.({
+            id: sector.id,
+            capacity: sector.capacity,
+          });
+        };
+
+        const handleHover = (sector: Omit<Sector, "className">) => {
+          if (props.disableRoofSelection && isRoof) return;
+          if (!isEnabled) return;
+          props.onHover?.({
+            id: sector.id,
+            capacity: sector.capacity,
+          });
+        };
+
+        const handleMouseOver = (sector: Omit<Sector, "className">) => {
+          if (props.disableRoofSelection && isRoof) return;
+          if (!isEnabled) return;
+          setMouseOver(sector.id);
+        };
+
+        return (
           <a
             key={sectorProps.id}
             id={sectorProps.id}
-            href=""
+            href={isEnabled ? sectorProps.id : undefined}
+            className={isEnabled ? "cursor-pointer" : "cursor-not-allowed"}
             onClick={(e) => handleClick(e, sectorProps)}
             onMouseOver={() => handleHover(sectorProps)}
             onMouseEnter={() => handleMouseOver(sectorProps)}
             onMouseLeave={() => setMouseOver(null)}
           >
             <path
-              data-disabled={props.enabledSectors && !props.enabledSectors.includes(sectorProps.id)}
+              data-disabled={!isEnabled}
               data-active={props.activeSector === sectorProps.id}
-              className="hover:fill-[#444] data-[disabled=true]:fill-[#333] data-[active=true]:fill-[coral]"
+              className="hover:fill-[#444] data-[disabled=true]:fill-[#333] data-[active=true]:fill-yellow-300"
               {...sectorProps}
             />
           </a>
-        ))
-      }
+        );
+      })}
     </svg>
   );
 }

--- a/src/config/sectors.tsx
+++ b/src/config/sectors.tsx
@@ -1,0 +1,1047 @@
+export const sectors = [
+  // Roof A
+  {
+    id: "roof-a-1",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M58.5 639.5L22.5 628.5L1.5 696L38 707.5L58.5 639.5Z"
+  },
+  {
+    id: "roof-a-2",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M109.5 445.5L143.5 462.5L62.5 628L28.5 610.5L109.5 445.5Z"
+  },
+  {
+    id: "roof-a-3",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M147.5 452.5L120 427L221 306L250 330.5L147.5 452.5Z"
+  },
+  {
+    id: "roof-a-4",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M381 227.5L357 197L234.5 296.5L258 326L381 227.5Z"
+  },
+  {
+    id: "roof-a-5",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M532.5 145.5L518.5 110L662.5 56L676.5 92L532.5 145.5Z"
+  },
+  {
+    id: "roof-a-6",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M684 89.5L675 53L821 19.5L829.5 57L684 89.5Z"
+  },
+  {
+    id: "roof-a-7",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M839 55.5L834 17.5L983.5 2.5L987.5 40.5L839 55.5Z"
+  },
+  {
+    id: "roof-a-8",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M994 40.5V2.5L1143 0.5L1144 38.5L994 40.5Z"
+  },
+  {
+    id: "roof-a-9",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1154 40L1158 1L1306.5 18.5L1301.5 56L1154 40Z"
+  },
+  {
+    id: "roof-a-10",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1456 90L1311 61L1318 20.5L1465.5 53.5L1456 90Z"
+  },
+  {
+    id: "roof-a-11",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1479 58.5L1466.5 94L1607.5 144L1618.5 107.5L1479 58.5Z"
+  },
+  {
+    id: "roof-a-12",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1784 196.5L1760 226L1883.5 325.5L1906 296L1784 196.5Z"
+  },
+  {
+    id: "roof-a-13",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1994 455L1890 332L1919.5 307L2023 429.5L1994 455Z"
+  },
+  {
+    id: "roof-a-14",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M2112 612.5L2078 630L1998 462L2033 446.5L2112 612.5Z"
+  },
+  {
+    id: "roof-a-15",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M2101.5 709.5L2084 640.5L2121.5 631L2138 699L2101.5 709.5Z"
+  },
+
+  // Roof B
+  
+  {
+    id: "roof-b-1",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M23 1090L5.5 1020.5L41 1010L60.5 1081.5L23 1090Z"
+  },
+  {
+    id: "roof-b-2",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M62 1089.5L27.5 1106L108 1274.5L142.5 1258.5L62 1089.5Z"
+  },
+  {
+    id: "roof-b-3",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M222 1414L120 1293L148.5 1267.5L251 1389L222 1414Z"
+  },
+  {
+    id: "roof-b-4",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M356.5 1524L236 1422.5L259.5 1393L381 1495L356.5 1524Z"
+  },
+  {
+    id: "roof-b-5",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M531 1577.5L517.5 1613.5L661.5 1662.5L674 1626.5L531 1577.5Z"
+  },
+  {
+    id: "roof-b-6",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M831.5 1661.5L684.5 1631L675.5 1665.5L824.5 1700.5L831.5 1661.5Z"
+  },
+  {
+    id: "roof-b-7",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M983 1716L833.5 1702L837 1664L987 1678L983 1716Z"
+  },
+  {
+    id: "roof-b-8",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1144.5 1717L994 1715.5L996 1677.5L1144.5 1679V1717Z"
+  },
+  {
+    id: "roof-b-9",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1306 1700L1158 1717L1154 1679.5L1303 1663L1306 1700Z"
+  },{
+    id: "roof-b-10",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1318 1699L1311 1662L1456.5 1630.5L1463.5 1668L1318 1699Z"
+  },
+  {
+    id: "roof-b-11",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1476 1662.5L1465 1625L1608.5 1576.5L1620.5 1612.5L1476 1662.5Z"
+  },
+  {
+    id: "roof-b-12",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1784.5 1523L1760.5 1493L1882.5 1392.5L1907.5 1422L1784.5 1523Z"
+  },
+  {
+    id: "roof-b-13",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M1920.5 1411.5L1891.5 1387.5L1992 1265.5L2022.5 1289.5L1920.5 1411.5Z"
+  },
+  {
+    id: "roof-b-14",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M2033 1275.5L1997.5 1258.5L2079.5 1090L2114 1106.5L2033 1275.5Z"
+  },
+  {
+    id: "roof-b-15",  
+    className: "seat",
+    fill: "white",
+    stroke: "black",
+    d: "M2116.5 1089.5L2080 1080L2100.5 1009L2137 1019L2116.5 1089.5Z"
+  },
+
+  // Floor 1
+  {
+    id: "101",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1645.5 398.5L1656 406L1580.5 512.5L1526.5 478.5L1592.5 369L1638.5 394L1697 305.5L1704.5 310.5L1645.5 398.5Z"
+  },
+  {
+    id: "102",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1774 516L1750.5 488L1660.5 577.5L1682.5 599.5L1774 516Z"
+  },
+  {
+    id: "103",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1843.5 608.5L1864.5 597.5L1870 608.5L1733.5 678L1688 608L1786.5 530.5L1816.5 565.5L1907 510L1911.5 515.5L1821 575L1843.5 608.5Z"
+  },
+  {
+    id: "104",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1983.5 667L1882 696.5L1890 727.5L1765.5 761.5L1736 685.5L1874 616L1881.5 630.5L1860 643L1879.5 687L1980.5 657.5L1983.5 667Z"
+  },
+  {
+    id: "105",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1895 746L1898.5 759.5L2002 737L2014.5 854H1776.5L1767 772.5L1895 746Z"
+  },
+  {
+    id: "106",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M2001 982L1897.5 959.5L1895 970.5L1768.5 944.5L1776 862.5H2012.5L2001 982Z"
+  },
+  {
+    id: "107",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1860 1076L1880 1087L1874.5 1099.5L1739 1031L1765 953L1890.5 988L1882 1023L1983 1052L1981 1059L1880 1030L1860 1076Z"
+  },
+  {
+    id: "108",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1907 1210L1817 1152L1788.5 1185L1687 1108L1734.5 1038L1870.5 1108L1865.5 1119.5L1844.5 1109.5L1823 1142.5L1912 1202.5L1907 1210Z"
+  },
+  {
+    id: "109",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1708 1271L1723 1289L1711 1298.5L1613.5 1179L1681.5 1114L1776 1200L1742 1239.5L1818 1315L1811.5 1321.5L1737 1245.5L1708 1271Z"
+  },
+  {
+    id: "110",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1696.5 1412L1638 1322.5L1593.5 1347L1528 1237L1606 1184.5L1704 1304L1694 1312L1678.5 1294L1644 1318.5L1703 1406.5L1696.5 1412Z"
+  },
+  {
+    id: "111",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1486.5 1399.5L1492.5 1420.5L1479 1426L1424 1282L1520 1240.5L1577 1356L1532.5 1380.5L1575 1477L1568.5 1480L1525 1383L1486.5 1399.5Z"
+  },
+  {
+    id: "112",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1399.5 1426L1347 1438L1315 1314L1415 1285L1470 1430L1459 1434.5L1450.5 1411L1408.5 1426L1437.5 1528.5L1429 1530L1399.5 1426Z"
+  },
+  {
+    id: "113",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1223 1462L1226.5 1485.5L1212 1487L1196.5 1333.5L1305.5 1316L1330 1442L1276.5 1454.5L1294 1559.5L1285 1561L1268 1456L1223 1462Z"
+  },
+  {
+    id: "114",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1133.5 1471.5L1079 1471L1075.5 1341L1186.5 1334.5L1203.5 1487.5L1189 1489L1187 1466L1141.5 1469L1148 1577.5L1139 1578L1133.5 1471.5Z"
+  },
+  {
+    id: "115",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M953.5 1466L951 1489L938 1488L952 1335L1064.5 1341L1060.5 1471L1006.5 1470.5L1001 1577.5H992.5L998.5 1469.5L953.5 1466Z"
+  },
+  {
+    id: "116",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M864 1455.5L809.5 1443L833.5 1317L943 1333L929 1487L915 1486L917 1464.5L873 1455.5L857.5 1561L845.5 1560L864 1455.5Z"
+  },
+  {
+    id: "117",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M681 1434.5L669.5 1430.5L724 1287L824 1313.5L792.5 1439L741 1427L714 1530.5L703 1527.5L733.5 1425L690 1410.5L681 1434.5Z"
+  },
+  {
+    id: "118",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M608.5 1380.5L564 1356L620 1243L716.5 1283.5L662 1428L646.5 1422.5L654 1401L616 1385L574 1483L565.5 1479L608.5 1380.5Z"
+  },
+  {
+    id: "119",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M446.5 1310.5L437 1303.5L533.5 1184.5L612 1238.5L546.5 1346.5L503 1322.5L444.5 1413L436.5 1409L494.5 1317.5L461.5 1294.5L446.5 1310.5Z"
+  },
+  {
+    id: "120",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M397 1239.5L364 1201.5L457.5 1115.5L527 1179.5L429.5 1297.5L418.5 1289.5L431.5 1271L405 1246L329.5 1323.5L322.5 1316.5L397 1239.5Z"
+  },
+  {
+    id: "121",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M276.5 1121L269.5 1109L406.5 1040.5L451.5 1108L351.5 1187L322.5 1153.5L233 1210.5L227 1204.5L317 1144L296 1110.5L276.5 1121Z"
+  },
+  {
+    id: "122",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M157.5 1059.5L155.5 1052L259 1023.5L249.5 987.5L375 953L404 1029.5L265.5 1102L258 1089L279 1076L260.5 1033L157.5 1059.5Z"
+  },
+  {
+    id: "123",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M124.5 864H362L371.5 944.5L245 972.5L242 960.5L137.5 984L124.5 864Z"
+  },
+  {
+    id: "124",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M241.5 757.5L244.5 746.5L370.5 772.5L362 853H124L137 733L241.5 757.5Z"
+  },
+  {
+    id: "125",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M259 628L265.5 616L402 686.5L373.5 762.5L249.5 728L259 692.5L154.5 665L158.5 655L263 683.5L280.5 638.5L259 628Z"
+  },
+  {
+    id: "126",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M407 677L451.5 607L352 531L322.5 565.5L232 509L226.5 515.5L316.5 572.5L295 605L276.5 595.5L269.5 608.5L407 677Z"
+  },
+  {
+    id: "127",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M458 602.5L479.5 578.5L389 487.5L364.5 516L458 602.5Z"
+  },
+  {
+    id: "128",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M441.5 306L502.5 394L546.5 370L611 478L556.5 513L483.5 406.5L495 397.5L437 308L441.5 306Z"
+  },
+  {
+    id: "129",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M653.5 316L645.5 295.5L661.5 289.5L715 432L620 473.5L562 361.5L608.5 336L582 280L539.5 298L519 261L563 235.5L572 230.5L620.5 214.5L631.5 210.5L649 254L589.5 275.5L616 332.5L653.5 316Z"
+  },
+  {
+    id: "130",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M728 247.5L741.5 289L792 277.5L824.5 401.5L725 429.5L670 286.5L680.5 282.5L689 304L732.5 291.5L720 251L728 247.5Z"
+  },
+  {
+    id: "131",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M917 252.5L914.5 232L927 231L944 380L834 399L811 273L863.5 261L856 220.5L865 218.5L872.5 260.5L917 252.5Z"
+  },
+  {
+    id: "131A",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1187.5 248L1189 227.5L1200 228.5L1185 379.5L1114 375L1116.5 292L1022 291L1023.5 374L952.5 379L938 229.5L953 228V247.5L997.5 244L996.5 221L1005.5 220.5L1006.5 244H1135L1135.5 220L1143.5 220.5L1143 245.5L1187.5 248Z"
+  },
+  {
+    id: "132",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1275.5 261L1328.5 273.5L1305.5 398L1195 381.5L1211.5 229.5L1226.5 231L1224 251L1267 258.5L1274.5 220L1282.5 221L1275.5 261Z"
+  },
+  {
+    id: "133",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1449.5 304.5L1459 282L1468.5 285.5L1414.5 429.5L1316.5 400.5L1346.5 277.5L1397.5 289.5L1410 247.5L1419.5 251L1407 292.5L1449.5 304.5Z"
+  },
+  {
+    id: "134",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1532 336L1577 360.5L1520 474.5L1424.5 433.5L1477.5 289L1493 295L1485.5 318.5L1524.5 332.5L1551.5 273L1491 252.5L1508 212L1566.5 235L1579 239L1617 260.5L1597.5 294.5L1560 277L1532 336Z"
+  },
+
+  // Floor 2
+  {
+    id: "201A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1820 403.5L1908.5 509L1816.5 565.5L1743.5 480L1820 403.5Z"
+  },
+  {
+    id: "202",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1982.5 657L1879.5 687L1860 643L1881.5 630.5L1864.5 597.5L1843.5 608.5L1821 575L1912.5 515L1941 558.5L1953 552L1970 585L1955.5 592.5L1982.5 657Z"
+  },
+  {
+    id: "203",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1882 696.5L1985.5 666.5L2004 736.5L1898.5 759.5L1882 696.5Z"
+  },
+  {
+    id: "204",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M2005 983L1985 1052.5L1882 1023L1897.5 959.5L2005 983Z"
+  },
+  {
+    id: "205",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1958 1127.5L1984.5 1060L1880 1030L1860 1076L1880 1087L1865.5 1119.5L1844.5 1109.5L1823 1142.5L1912 1202.5L1941 1160.5L1953.5 1167L1969.5 1133.5L1958 1127.5Z"
+  },
+  {
+    id: "206",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1819.5 1316.5L1910 1212L1817 1152L1742 1239.5L1819.5 1316.5Z"
+  },
+  {
+    id: "207",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1737 1245.5L1812.5 1322.5L1774 1357L1784.5 1369L1757 1392.5L1745.5 1379L1704.5 1408.5L1644 1318.5L1678.5 1294L1694 1312L1723 1289L1708 1271L1737 1245.5Z"
+  },
+  {
+    id: "208",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1638 1322.5L1697.5 1413.5L1576.5 1480.5L1532.5 1380.5L1638 1322.5Z"
+  },
+  {
+    id: "209",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1486.5 1516.5L1438.5 1531.5L1408.5 1426L1450.5 1411L1459 1434.5L1492.5 1420.5L1486.5 1399.5L1525 1383L1571 1485.5L1521.5 1505L1527 1518L1491 1530L1486.5 1516.5Z"
+  },
+  {
+    id: "210",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1429 1530L1294.5 1563L1276.5 1454.5L1399.5 1426L1429 1530Z"
+  },
+  {
+    id: "211",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1200.5 1578L1148 1579.5L1141.5 1469L1187 1466L1189 1489L1226.5 1485.5L1223 1462L1268 1456L1285.5 1564L1237.5 1572L1238 1585L1201 1590L1200.5 1578Z"
+  },
+  {
+    id: "212A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1001 1579L1139 1580L1133.5 1471.5L1006.5 1470.5L1001 1579Z"
+  },
+  {
+    id: "213",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M903 1571.5L857 1564.5L873 1455.5L917 1464.5L915 1486L951 1489L953.5 1466L998.5 1469.5L992.5 1578.5L940.5 1577V1589L902 1586L903 1571.5Z"
+  },
+  {
+    id: "214",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M713 1534L845 1562.5L864 1455.5L741 1427L713 1534Z"
+  },
+  {
+    id: "215",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M619 1506L573 1485.5L616 1385L654 1401L646.5 1422.5L681 1434.5L690 1410.5L733.5 1425L702 1531L655 1517L650.5 1529.5L615 1517.5L619 1506Z"
+  },
+  {
+    id: "216",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M443 1415.5L564.5 1481L608.5 1380.5L503 1322.5L443 1415.5Z"
+  },
+  {
+    id: "217",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M365 1358L329 1324L405 1246L431.5 1271L418.5 1289.5L446.5 1310.5L461.5 1294.5L494.5 1317.5L436.5 1409L396 1383L382 1399.5L351 1376.5L365 1358Z"
+  },
+  {
+    id: "218",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M233.5 1214L321.5 1317.5L397 1239.5L322.5 1153.5L218 1220L220 1222.5L233.5 1214Z"
+  },
+  {
+    id: "219",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M156.5 1064.5L143.5 1068V1063L260.5 1033L279 1076L258 1089L276.5 1121L296 1110.5L317 1144L227 1204.5L199.5 1162L187.5 1168.5L169 1135L183.5 1128L156.5 1064.5Z"
+  },
+  {
+    id: "220",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M118.5 988.5L242 960.5L259 1023.5L155.5 1052L138.5 990L118.5 994V988.5Z"
+  },
+  {
+    id: "221",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M259 692.5L154.5 665L137 733L241.5 757.5L259 692.5Z"
+  },
+  {
+    id: "222",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M202 556L226.5 515.5L316.5 572.5L295 605L276.5 595.5L259 628L280.5 638.5L263 683.5L158.5 655L186 590L169 583L187.5 549.5L202 556Z"
+  },
+  {
+    id: "223A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M322.5 565.5L232.5 509L320 401.5L397 478L322.5 565.5Z"
+  },
+  {
+    id: "224",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M366 361L329.5 396L406 470.5L432 446.5L417 426.5L447.5 404.5L463 423L495 397.5L437 308L394 338.5L384 325.5L355 349L366 361Z"
+  },
+  {
+    id: "225",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M441.5 306L519 261L539.5 298L582 280L608.5 336L502.5 394L441.5 306Z"
+  },
+  {
+    id: "226",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M616 332.5L589.5 275.5L713.5 231L732.5 291.5L689 304L680.5 282.5L645.5 295.5L653.5 316L616 332.5Z"
+  },
+  {
+    id: "227",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M741.5 289L722.5 230L852 198L863.5 261L741.5 289Z"
+  },
+  {
+    id: "228",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M872.5 260.5L861 197L995 182L997.5 244L953 247.5V228L914.5 232L917 252.5L872.5 260.5Z"
+  },
+  {
+    id: "229",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1006.5 244L1004.5 182H1136.5L1135 244H1006.5Z"
+  },
+  {
+    id: "230",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1187.5 248L1143 245.5L1145 182L1279 197.5L1267 258.5L1224 251L1226.5 231L1189 227.5L1187.5 248Z"
+  },
+  {
+    id: "231",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1275.5 261L1286.5 199L1415.5 228.5L1397.5 289.5L1275.5 261Z"
+  },
+  {
+    id: "232",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1407 292.5L1425.5 230.5L1551.5 273L1524.5 332.5L1485.5 318.5L1493 295L1459 282L1449.5 304.5L1407 292.5Z"
+  },
+  {
+    id: "233",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1638.5 394L1697 305.5L1617 260.5L1597.5 294.5L1560 277L1532 336L1638.5 394Z"
+  },
+  {
+    id: "234",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1679.5 423.5L1645.5 398.5L1704.5 310.5L1746.5 339L1756.5 327L1785 350L1775.5 363.5L1813.5 396.5L1737.5 472L1708 446.5L1723.5 428.5L1694.5 405L1679.5 423.5Z"
+  },
+
+  // Floor 3
+  {
+    id: "301A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1579 239L1697 305.5L1748 219L1622.5 150L1579 239Z"
+  },
+  {
+    id: "302",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1760 226L1883.5 325.5L1813.5 396.5L1775.5 363.5L1790 343.5L1762 320.5L1746.5 339L1704.5 310.5L1760 226Z"
+  },
+  {
+    id: "303",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1890 332.5L1994 455L1908.5 509L1820 403.5L1890 332.5Z"
+  },
+  {
+    id: "304",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1982.5 657.5L2078 630L1998 462L1912.5 515L1941 558.5L1962 547.5L1979.5 580.5L1955.5 592.5L1982.5 657.5Z"
+  },
+  {
+    id: "305",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M2084 640.5L2101.5 709.5L2004 736.5L1985.5 666.5L2084 640.5Z"
+  },
+  {
+    id: "306",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M2100.5 1009L2080 1080L1984 1055.5L2003.5 988L2100.5 1009Z"
+  },
+  {
+    id: "307",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M2079.5 1090L1997.5 1258.5L1912 1202.5L1941 1160.5L1961 1170.5L1978 1138L1958 1127.5L1984.5 1060L2079.5 1090Z"
+  },
+  {
+    id: "308",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1891.5 1387.5L1992 1265.5L1910 1212L1819.5 1316.5L1891.5 1387.5Z"
+  },
+  {
+    id: "309",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1882.5 1392.5L1760.5 1493L1704.5 1408.5L1746 1379L1762.5 1399.5L1789.5 1374.5L1774 1357L1812.5 1322.5L1882.5 1392.5Z"
+  },
+  {
+    id: "310A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1618 1573L1577 1480.5L1697.5 1413.5L1755 1499L1618 1573Z"
+  },
+  {
+    id: "311",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1608.5 1576.5L1465 1625L1438.5 1531.5L1486.5 1516.5L1494.5 1539.5L1530.5 1527L1521.5 1505L1571 1485.5L1608.5 1576.5Z"
+  },
+  {
+    id: "312",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1311 1662L1456 1630.5L1429 1530L1294.5 1563L1311 1662Z"
+  },
+  {
+    id: "313",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1154 1679.5L1303 1663L1285.5 1564L1237.5 1572L1239 1596.5L1201.5 1600L1200.5 1578L1148 1579.5L1154 1679.5Z"
+  },
+  {
+    id: "314",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M996 1677.5L1144.5 1679L1139 1580L1001 1579L996 1677.5Z"
+  },
+  {
+    id: "315",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M837 1664L987 1678L991 1578.5L940.5 1577V1597.5L902 1595L903 1571.5L854.5 1564.5L837 1664Z"
+  },
+  {
+    id: "316",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M684.5 1631L831.5 1661.5L843 1562L709 1533L684.5 1631Z"
+  },
+  {
+    id: "317",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M531 1577.5L674 1626.5L702 1531L655 1517L646.5 1539.5L611.5 1527.5L619 1506L573 1485.5L531 1577.5Z"
+  },
+  {
+    id: "318A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M523 1573.5L386.5 1500L443 1415.5L564.5 1481L523 1573.5Z"
+  },
+  {
+    id: "319",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M259.5 1393L381 1495L436.5 1409L396 1383L382 1399.5L351 1376.5L365 1358L329 1324L259.5 1393Z"
+  },
+  {
+    id: "320",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M251 1389L148.5 1267.5L233.5 1214L321.5 1317.5L251 1389Z"
+  },
+  {
+    id: "321",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M62 1089.5L142.5 1258.5L227.5 1205L199.5 1162L179 1173L161 1139L183.5 1128L156.5 1064.5L62 1089.5Z"
+  },
+  {
+    id: "322",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M41 1010L138.5 990L156.5 1055.5L60.5 1081.5L41 1010Z"
+  },
+  {
+    id: "323",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M38 707.5L58.5 639.5L154.5 665L137 733L38 707.5Z"
+  },
+  {
+    id: "324",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M226.5 515.5L143.5 462.5L62.5 628L158.5 655L186 590L163 580.5L180 546.5L202 556L226.5 515.5Z"
+  },
+  {
+    id: "325",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M320 401.5L232.5 509L148 452.5L250 330.5L320 401.5Z"
+  },
+  {
+    id: "326",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M258 326L381 227.5L437 308L394.5 338.5L381 321L351.5 344.5L366 361.5L329.5 396L258 326Z"
+  },
+  {
+    id: "327A/B",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M445 304L386.5 220.5L523 146L563 235.5L445 304Z"
+  },
+  {
+    id: "328",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M532.5 145.5L676.5 92L703.5 186L655 202.5L647.5 180.5L611.5 192.5L620.5 214.5L572 230.5L532.5 145.5Z"
+  },
+  {
+    id: "329",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M829.5 57L684 89.5L711.5 185.5L845.5 155L829.5 57Z"
+  },
+  {
+    id: "330",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M987.5 40.5L839 55.5L857 153L905.5 147L902.5 122.5L941.5 119.5L942.5 143L993.5 139.5L987.5 40.5Z"
+  },
+  {
+    id: "331",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M994 40.5L1144 38.5L1140 140H1002.5L994 40.5Z"
+  },
+  {
+    id: "332",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1154 40L1301.5 56L1287 154.5L1237.5 148.5L1239.5 125L1202 121.5L1199.5 142.5L1149.5 140L1154 40Z"
+  },
+  {
+    id: "333",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1311 61L1456 90L1430 186L1296 157.5L1311 61Z"
+  },
+  {
+    id: "334",  
+    className: "seat",
+    capacity: 10,
+    fill: "white",
+    stroke: "black",
+    d: "M1488 204L1438 189.5L1466.5 94L1607.5 144L1566.5 235L1521 217L1530.5 194L1497 180.5L1488 204Z"
+  },
+];
+
+export type Sector = typeof sectors[0];

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -84,10 +84,7 @@ function SeatPage({
         </div>
         <SeatNav current={seat.section} />
         <div className="px-4">
-          <img
-            src="/map.png"
-            className="w-full max-w-screen-md h-auto border mx-auto"
-          />
+          <SectorNav />
         </div>
         <BuiltBy />
       </div>

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -12,6 +12,7 @@ import NavBar from "../components/NavBar";
 import { seats } from "../constant";
 import Image from "next/image";
 import SEOHead from "@/components/SEOHead";
+import SectorNav from "@/components/SectorNav";
 
 export const getStaticProps: GetStaticProps<{
   seat: (typeof seats)[number];

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -70,8 +70,8 @@ function SeatPage({
           <p className="text-center">{description}</p>
         </div>
         <div className="flex flex-col md:flex-row space-x-0 space-y-4 md:space-y-0 md:space-x-4 justify-center mt-8 px-4 items-center w-full mx-auto max-w-screen-xl">
-          {[...seat.photosUrl].map((item) => (
-            <div className="relative h-[280px] md:h-[400px] w-full">
+          {seat.photosUrl.map((item) => (
+            <div key={item} className="relative h-[280px] md:h-[400px] w-full">
               <PhotoView key={item} src={`/seats/${item}`}>
                 <Image
                   fill

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ export default function Home() {
         <h1 className="mt-8 text-lg font-bold text-center md:text-2xl">
           Stadium Nasional Bukit Jalil Seating View Plan
         </h1>
-        <img src="/map.png" className="w-full max-w-screen-lg h-auto border" />
+        <SectorNav />
       </div>
       <SeatNav />
       <BuiltBy />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import SeatNav from "@/components/SeatNav";
 import BuiltBy from "../components/BuiltBy";
 import NavBar from "../components/NavBar";
 import SEOHead from "@/components/SEOHead";
+import SectorNav from "@/components/SectorNav";
 
 export default function Home() {
   return (


### PR DESCRIPTION
Replacing the existing stadium map image with vectors. These are the improvements:

- Vectors are used to map all stadium sectors, allowing individual interactions.
- Map should be able to enable/disable sectors, including the roof sector (for reference).
- Map should be responsive, work with all resolutions.
- Map should be accessible by keyboard and touch (a11y)
- This map should be scalable along with the `seats` information, so no further modification of the map is needed, unless there is a need to add more info of each sectors, such as `capacity`. Now, all `capacity` value is hardcoded, but should be ready for further improvement.
- The active sector should be highlighted on the map when visiting each sector - easier to identify current active sector user is viewing.

You might want to reposition, but from my perspective, it should be okay, but it is up to you.

Demo:

https://github.com/afrieirham/bukitjalilstadium/assets/32460534/6670944b-6246-4f6d-aaa1-ac4d859a21c2
